### PR TITLE
Remove duplicate string in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Use the following environment variables for configuration:
 For authentication one or multiple of the following passwords can be set:
 
 - `CNTLM_PASSWORD` (*optional*): plain text password to login to upstream proxy
-- `CNTLM_CNTLM_PASSNTLMV2` (*optional*): NTLMv2 password to login to upstream proxy
+- `CNTLM_PASSNTLMV2` (*optional*): NTLMv2 password to login to upstream proxy
 - `CNTLM_PASSNT` (*optional*): PassNt password to login to upstream proxy
 - `CNTLM_PASSLM` (*optional*): PassLM password to login to upstream proxy
 


### PR DESCRIPTION
`CNTLM_CNTLM_PASSNTLMV2` -> `CNTLM_PASSNTLMV2`
to be consistent with https://github.com/bachp/cntlm/blob/5fc7091c3efe428d258d28991ab0e6aa8af28644/run.sh#L28